### PR TITLE
Fix issue #17: Wrong ordering of language drop-down

### DIFF
--- a/Sources/CLanguageInterface.cpp
+++ b/Sources/CLanguageInterface.cpp
@@ -173,7 +173,7 @@ void AddInterface(char *s, T* i)
 bool CompareInterfacesByName(const CLanguageInterface *first,
 	const CLanguageInterface *second)
 {
-	return collator.GreaterOrEqual(second->Name(), first->Name(), B_COLLATE_SECONDARY);
+	return collator.Greater(second->Name(), first->Name(), B_COLLATE_SECONDARY);
 } /* CompareInterfacesByName */
 
 void CLanguageInterface::SetupLanguageInterfaces()


### PR DESCRIPTION
I explained the source of the problem [here](https://github.com/olta/pe/issues/17#issuecomment-66934406); AFAIK, all that can be done is sort the list of languages by name before the drop-down is populated. I checked if the Be/Haiku API had some way of shwoing subdirectories in alphabetical order, but I have not come across any.
