### PR TITLE
Unbind B_FUNCTION_KEY from "Help"

### DIFF
--- a/Resources/Bindings.r
+++ b/Resources/Bindings.r
@@ -403,7 +403,7 @@ resource rtyp_Bind (rid_Bind_WindowMenu, "Bindings for window menu") {
 resource rtyp_Bind (rid_Bind_HelpMenu, "Bindings for help menu") {
 	{
 //		0,				0,		0, 		0,			msg_About,
-		0,				B_FUNCTION_KEY,	0,	0,		msg_Help
+//		0,				B_FUNCTION_KEY,	0,	0,		msg_Help
 	}
 };
 


### PR DESCRIPTION
Because all the keys has raw_char = B_FUNCTION_KEY are triggered to display document in Web+
Users should delete "keybindings-v2" file under your Pe settings (~/config/settings/pe) to generate the keymap again.

Fixes https://dev.haiku-os.org/ticket/12857