### PR TITLE
Removed line 461 as it was causing a compile error.

### DIFF
--- a/Languages/Sources/HtmlCssJsPhp_Popup.cpp
+++ b/Languages/Sources/HtmlCssJsPhp_Popup.cpp
@@ -458,7 +458,6 @@ const char *JavaScript(const char *txt, PopupList &lstJsFunctions, PopupList &ls
 
 const char *PhpScript(const char *txt, PopupList &lstPhpFunctions, PopupList &lstPhpClasses, bool sorted)
 {
-	std::map <int,int,int> headings;
 	BString class_name;
 	while (*txt)
 	{


### PR DESCRIPTION
 A std::map cannot have 3 parameters. Additionally, the variable created (headings) was never used so the line was unnecessary.