### PR TITLE
Syntax Highlighting for RDEF Files

### DIFF
--- a/Languages/Sources/Rez_Language.cpp
+++ b/Languages/Sources/Rez_Language.cpp
@@ -37,7 +37,7 @@
 #include "HColorUtils.h"
 
 _EXPORT const char kLanguageName[] = "Rez";
-_EXPORT const char kLanguageExtensions[] = "r;rez";
+_EXPORT const char kLanguageExtensions[] = "r;rez;rdef";
 _EXPORT const char kLanguageCommentStart[] = "//";
 _EXPORT const char kLanguageCommentEnd[] = "";
 _EXPORT const char kLanguageKeywordFile[] = "keywords.rez";


### PR DESCRIPTION
This is a rather quick and dirty fix. Since rez's syntax is close to identical to rdef's, it doesn't hurt to have rdef files highlighted using rez's syntax highlighter.