### PR TITLE
Allow invoking the "Find differences" mode from the command line.

### DIFF
--- a/Sources/CDiffWindow.cpp
+++ b/Sources/CDiffWindow.cpp
@@ -57,8 +57,7 @@ inline int compare(const char *a, const char *b)
 
 const unsigned long
 	msg_InvokeScriptItem = 'InvS',
-	msg_SelectScriptItem = 'SelS',
-	msg_Add2Files = 'Ad2F';
+	msg_SelectScriptItem = 'SelS';
 
 class CDiffToolBar : public PToolBar {
 public:

--- a/Sources/PMessages.h
+++ b/Sources/PMessages.h
@@ -198,6 +198,7 @@
 #define msg_RefreshDiffs				'RfrD'
 #define msg_DiffFile1					'Dff1'
 #define msg_DiffFile2					'Dff2'
+#define msg_Add2Files					'Ad2F'
 
 #define msg_SelectError					'SelE'
 


### PR DESCRIPTION
When called as `Pe --diff file1 file2`, it automatically opens the "File differences" dialog for both files, ready to be used.

First attempt at adding this functionality. Suggestions always welcomed!

Ideally, `lpe` should also be able to call this mode. Haven't looked at that yet.