### PR TITLE
Make PDoc::OpenInclude() support absolute paths.

### DIFF
--- a/Sources/PDoc.cpp
+++ b/Sources/PDoc.cpp
@@ -496,6 +496,17 @@ void PDoc::OpenInclude(const char *incl)
 			return;
 		}
 
+		// Handle absolute paths
+		if (strncmp(incl, "/", 1) == 0)
+		{
+			BPath path(incl);
+			if (e.SetTo(path.Path(), true) == B_OK && e.Exists() && e.IsFile())
+			{
+				FailOSErr(e.GetRef(&doc));
+				found = true;
+			}
+		}
+
 		if (! found && fText->GetCWD())
 		{
 			FailOSErr(d.SetTo(fText->GetCWD()));


### PR DESCRIPTION
This was preventing, for example, Lout's languge addon use of the "open includes" feature, as it was computing absolute paths that Pe's code didn't seemed to handle (at least when the files where not on the same dir as the doc being edited).