### PR TITLE
Partial/alternative solution to #64.

### DIFF
--- a/Resources/Bindings.r
+++ b/Resources/Bindings.r
@@ -221,6 +221,7 @@ resource rtyp_Cmnd (rid_Cmnd_Miscellaneous, "Miscellaneous") {
 		kmsg_SplitWindow,							"Split window",
 		msg_CancelCommand,							"Cancel executing command",
 		msg_Execute,								"Execute command",
+		msg_ExecuteToWorksheet,						"Execute command (w/ output to Worksheet)",
 		msg_SwitchHeaderSource,						"Open header/source",
 	}
 };
@@ -421,6 +422,7 @@ resource rtyp_Bind (rid_Bind_Miscellaneous, "Miscellaneous bindings") {
 	{
 		Ctrl,			0x63,	0,		0,			msg_CancelCommand,
 		Cmd,			0x0a,	0,		0,			msg_Execute,
+		Cmd|Shift,		0x0a,	0,		0,			msg_ExecuteToWorksheet,
 //		0,				0x0a,	0,		0,			msg_Execute,
 		Cmd,			0x09,	0,		0,			msg_SwitchHeaderSource
 	}

--- a/Sources/PExec.h
+++ b/Sources/PExec.h
@@ -43,11 +43,12 @@ class PErrorWindow;
 
 class PExec : public MThread {
 public:
-			PExec(PText *txt, const char *cmd, const char *wd);
+			PExec(PText *txt, const char *cmd, const char *wd, PText *dest = NULL);
 			~PExec();
 
 virtual	long Execute();
 
+			PText *fDest;
 			PText *fText;
 			BLooper *fWindow;
 			PErrorWindow *fErrorWindow;

--- a/Sources/PMessages.h
+++ b/Sources/PMessages.h
@@ -108,6 +108,7 @@
 	
 #define msg_OutputWillFollow			'OutP'
 #define msg_Execute						'Exec'
+#define msg_ExecuteToWorksheet			'ExWs'
 #define msg_ExecFinished				'Fnsh'
 #define msg_TypeString					'TypS'
 #define msg_Preferences					'Pref'

--- a/Sources/PText.cpp
+++ b/Sources/PText.cpp
@@ -4447,10 +4447,12 @@ const char
 #include "PExec.h"
 #include "PErrorWindow.h"
 
-PExec::PExec(PText *txt, const char *cmd, const char *wd)
+PExec::PExec(PText *txt, const char *cmd, const char *wd, PText *dest)
 	: MThread("execvp")
 {
 	fText = txt;
+	fDest = dest; // destination for "msg_ExecFinished" if not NULL.
+
 	fWindow = fText->Looper();
 
 	BPath appDirPath, settingsDirPath;
@@ -4637,14 +4639,17 @@ long PExec::Execute()
 	}
 
 	BMessage msg(msg_ExecFinished);
-	fWindow->PostMessage(&msg, fText);
+	if (fDest != NULL)
+		fDest->Looper()->PostMessage(&msg, fDest);
+	else
+		fWindow->PostMessage(&msg, fText);
 
 	return 0;
 } /* PExec::Execute */
 
 // #pragma mark -
 
-void PText::ExecuteSelection()
+void PText::ExecuteSelection(bool outputToWorkSheet)
 {
 	if (fExec)
 	{
@@ -4669,7 +4674,28 @@ void PText::ExecuteSelection()
 		fText.Copy(s, from, to - from);
 	}
 
-	fExec = new PExec(this, s, fCWD);
+	PText* outputText = this;
+	if (outputToWorkSheet)
+	{
+		if (!this->Doc()->IsWorksheet())
+		{
+			// We're not the Worksheet, is one already open?.
+			PDoc *doc = PDoc::GetWorksheet();
+
+			if (doc && !doc->IsWorksheet()) // GetWorksheet() bogus?
+			{
+				// Let's open it ourselves.
+				PApp *app = dynamic_cast<PApp*>(be_app);
+				doc = app->OpenWorksheet();
+			}
+			outputText = doc->TextView();
+		}
+	}
+
+	// if outputText != this, PExec's fWindow needs to be set to *this* 'this', otherwise
+	// the doc window never gets the msg_ExecFinished message, causing the
+	// "Execute Command" button to gets stuck on low.
+	fExec = new PExec(outputText, s, fCWD, (outputText != this) ? this : NULL);
 	fExec->Run();
 	Doc()->ButtonBar()->SetDown(msg_Execute, true);
 
@@ -6125,6 +6151,10 @@ void PText::MessageReceived(BMessage *msg)
 
 			case msg_Execute:
 				ExecuteSelection();
+				break;
+
+			case msg_ExecuteToWorksheet:
+				ExecuteSelection(true);
 				break;
 
 			case msg_CancelCommand:

--- a/Sources/PText.h
+++ b/Sources/PText.h
@@ -265,7 +265,7 @@ virtual		void FrameResized(float w, float h);
 			void JumpToFunction(const char *func, int32 offset);
 			void FindNextError(bool backward);
 
-			void ExecuteSelection();
+			void ExecuteSelection(bool outputToWorkSheet = false);
 			void KillCurrentJob();
 			void PrepareForOutput();
 			void SetCWD(const char *cwd);


### PR DESCRIPTION
Added a new "Execute command and send output to Worksheet" command. Default keybinding is CMD+Shift+ENTER.

On existing Pe installations, you need to manually assign a keybinding for the new command, under:

Preferences->Keybindings->Miscellaneous