### PR TITLE
Fix warnings (mostly when using GCC13)

### DIFF
--- a/Languages/Sources/Antlr_Language.cpp
+++ b/Languages/Sources/Antlr_Language.cpp
@@ -37,14 +37,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-extern "C" {
-_EXPORT const char kLanguageName[] = "Antlr";
-_EXPORT const char kLanguageExtensions[] = "g;tree.g";
-_EXPORT const char kLanguageCommentStart[] = "//";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.g";
-_EXPORT const int16 kInterfaceVersion = 2;
-}
+const char kLanguageName[] = "Antlr";
+const char kLanguageExtensions[] = "g;tree.g";
+const char kLanguageCommentStart[] = "//";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.g";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START, IDENT, OTHER, COMMENT, LCOMMENT, STRING,

--- a/Languages/Sources/Asm_Language.cpp
+++ b/Languages/Sources/Asm_Language.cpp
@@ -8,14 +8,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-extern "C" {
-_EXPORT const char kLanguageName[] = "ASM-x86";
-_EXPORT const char kLanguageExtensions[] = "as;asm;ASM;nas;s;S";
-_EXPORT const char kLanguageCommentStart[] = ";";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.asm";
-_EXPORT const int16 kInterfaceVersion = 2;
-}
+const char kLanguageName[] = "ASM-x86";
+const char kLanguageExtensions[] = "as;asm;ASM;nas;s;S";
+const char kLanguageCommentStart[] = ";";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.asm";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START, IDENT, COMMENT, LCOMMENT, STRING, NUMERIC, OPERATOR, SYMBOL, LEAVE

--- a/Languages/Sources/Cpp_Language.cpp
+++ b/Languages/Sources/Cpp_Language.cpp
@@ -43,14 +43,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-extern "C" {
-_EXPORT const char kLanguageName[] = "C/C++";
-_EXPORT const char kLanguageExtensions[] = "c;h;C;H;cc;hh;cpp;hpp;cxx;hxx;cp;hp";
-_EXPORT const char kLanguageCommentStart[] = "//";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.cpp";
-_EXPORT const int16 kInterfaceVersion = 2;
-}
+const char kLanguageName[] = "C/C++";
+const char kLanguageExtensions[] = "c;h;C;H;cc;hh;cpp;hpp;cxx;hxx;cp;hp";
+const char kLanguageCommentStart[] = "//";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.cpp";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START				= 0x00,

--- a/Languages/Sources/D_Language.cpp
+++ b/Languages/Sources/D_Language.cpp
@@ -42,16 +42,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-
-extern "C" {
-	_EXPORT const char	kLanguageName[]			= "D";
-	_EXPORT const char	kLanguageExtensions[]	= "d";
-	_EXPORT const char	kLanguageCommentStart[]	= "//";
-	_EXPORT const char	kLanguageCommentEnd[]	= "";
-	_EXPORT const char	kLanguageKeywordFile[]	= "keywords.d";
-	_EXPORT const int16	kInterfaceVersion		= 2;
-}
-
+const char	kLanguageName[]			= "D";
+const char	kLanguageExtensions[]	= "d";
+const char	kLanguageCommentStart[]	= "//";
+const char	kLanguageCommentEnd[]	= "";
+const char	kLanguageKeywordFile[]	= "keywords.d";
+const int16	kInterfaceVersion		= 2;
 
 enum {
 	START		= 0x00,

--- a/Languages/Sources/Diff_Language.cpp
+++ b/Languages/Sources/Diff_Language.cpp
@@ -37,14 +37,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-extern "C" {
-_EXPORT const char kLanguageName[] = "Diff";
-_EXPORT const char kLanguageExtensions[] = "diff;patch;patchset";
-_EXPORT const char kLanguageCommentStart[] = "";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.diff";
-_EXPORT const int16 kInterfaceVersion = 2;
-}
+const char kLanguageName[] = "Diff";
+const char kLanguageExtensions[] = "diff;patch;patchset";
+const char kLanguageCommentStart[] = "";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.diff";
+const int16 kInterfaceVersion = 2;
 
 // #pragma mark - coloring
 

--- a/Languages/Sources/HtmlCssJsPhp_Language.cpp
+++ b/Languages/Sources/HtmlCssJsPhp_Language.cpp
@@ -53,12 +53,12 @@ enum Language {
 	kLanguagePhp
 };
 
-_EXPORT const char kLanguageName[]         = "HTML-CSS-JS-PHP";
-_EXPORT const char kLanguageExtensions[]   = "html;htm;php";
-_EXPORT const char kLanguageCommentStart[] = "<!--";
-_EXPORT const char kLanguageCommentEnd[]   = "-->";
-_EXPORT const char kLanguageKeywordFile[]  = "keywords.html-css-js-php";
-_EXPORT const int16 kInterfaceVersion      = 2;
+const char kLanguageName[]         = "HTML-CSS-JS-PHP";
+const char kLanguageExtensions[]   = "html;htm;php";
+const char kLanguageCommentStart[] = "<!--";
+const char kLanguageCommentEnd[]   = "-->";
+const char kLanguageKeywordFile[]  = "keywords.html-css-js-php";
+const int16 kInterfaceVersion      = 2;
 
 enum {
 	START = 0,

--- a/Languages/Sources/HtmlJs_Language.cpp
+++ b/Languages/Sources/HtmlJs_Language.cpp
@@ -38,12 +38,14 @@
 
 #include <strings.h>
 
-_EXPORT const char kLanguageName[] = "HTML-JS";
-_EXPORT const char kLanguageExtensions[] = "html;htm";
-_EXPORT const char kLanguageCommentStart[] = "<!";
-_EXPORT const char kLanguageCommentEnd[] = ">";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.html-js";
-_EXPORT const int16 kInterfaceVersion = 2;
+extern "C" {
+	const char kLanguageName[] = "HTML-JS";
+	const char kLanguageExtensions[] = "html;htm";
+	const char kLanguageCommentStart[] = "<!";
+	const char kLanguageCommentEnd[] = ">";
+	const char kLanguageKeywordFile[] = "keywords.html-js";
+	const int16 kInterfaceVersion = 2;
+}
 
 enum {
 	START = 0,

--- a/Languages/Sources/Html_Language.cpp
+++ b/Languages/Sources/Html_Language.cpp
@@ -36,12 +36,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-_EXPORT const char kLanguageName[] = "HTML";
-_EXPORT const char kLanguageExtensions[] = "html;htm";
-_EXPORT const char kLanguageCommentStart[] = "<!";
-_EXPORT const char kLanguageCommentEnd[] = ">";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.html";
-_EXPORT const int16 kInterfaceVersion = 2;
+const char kLanguageName[] = "HTML";
+const char kLanguageExtensions[] = "html;htm";
+const char kLanguageCommentStart[] = "<!";
+const char kLanguageCommentEnd[] = ">";
+const char kLanguageKeywordFile[] = "keywords.html";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START,

--- a/Languages/Sources/Html_Popup.cpp
+++ b/Languages/Sources/Html_Popup.cpp
@@ -138,14 +138,12 @@ const char *Anchor(const char *txt, CLanguageProxy& ao)
 			if (*txt == 0)
 				break;
 			
-			char *p = name + kMaxNameSize;
 			int l = std::min(kMaxNameSize - 1, txt - anchor - 1);
 			strncpy(name, anchor, l);
 			name[l] = 0;
-			
-			sprintf(p, "A: %s", name);
-			
-			ao.AddFunction(p, name, offset);
+
+			BString tmp;
+			ao.AddFunction(tmp.SetToFormat("A: %s", name).String(), name, offset);
 		}
 	}
 	while (false);

--- a/Languages/Sources/Jam_Language.cpp
+++ b/Languages/Sources/Jam_Language.cpp
@@ -32,12 +32,14 @@
 class ParseContext;
 class Token;
 
-_EXPORT const char kLanguageName[] = "Jam";
-_EXPORT const char kLanguageExtensions[] = "Jamfile;Jamrules;Jambase";
-_EXPORT const char kLanguageCommentStart[] = "#";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.jam";
-_EXPORT const int16 kInterfaceVersion = 2;
+extern "C" {
+	const char kLanguageName[] = "Jam";
+	const char kLanguageExtensions[] = "Jamfile;Jamrules;Jambase";
+	const char kLanguageCommentStart[] = "#";
+	const char kLanguageCommentEnd[] = "";
+	const char kLanguageKeywordFile[] = "keywords.jam";
+	const int16 kInterfaceVersion = 2;
+}
 
 // #pragma mark ----- tokens -----
 

--- a/Languages/Sources/Java_Language.cpp
+++ b/Languages/Sources/Java_Language.cpp
@@ -36,12 +36,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-_EXPORT const char kLanguageName[] = "Java";
-_EXPORT const char kLanguageExtensions[] = "java";
-_EXPORT const char kLanguageCommentStart[] = "//";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.java";
-_EXPORT const int16 kInterfaceVersion = 2;
+	const char kLanguageName[] = "Java";
+	const char kLanguageExtensions[] = "java";
+	const char kLanguageCommentStart[] = "//";
+	const char kLanguageCommentEnd[] = "";
+	const char kLanguageKeywordFile[] = "keywords.java";
+	const int16 kInterfaceVersion = 2;
 
 enum {
 	START, IDENT, OTHER, COMMENT, LCOMMENT, STRING,

--- a/Languages/Sources/Lout_Language.cpp
+++ b/Languages/Sources/Lout_Language.cpp
@@ -47,13 +47,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-_EXPORT const char kLanguageName[] = "Lout";
-_EXPORT const char kLanguageExtensions[] = "lt;ld";
-_EXPORT const char kLanguageCommentStart[] = "#";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.lt";
-_EXPORT const int16 kInterfaceVersion = 2;
-
+const char kLanguageName[] = "Lout";
+const char kLanguageExtensions[] = "lt;ld";
+const char kLanguageCommentStart[] = "#";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.lt";
+const int16 kInterfaceVersion = 2;
 
 static inline bool
 isOperator(char c)

--- a/Languages/Sources/Lua_Language.cpp
+++ b/Languages/Sources/Lua_Language.cpp
@@ -6,14 +6,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-extern "C" {
-_EXPORT const char kLanguageName[] = "Lua";
-_EXPORT const char kLanguageExtensions[] = "lua;Lua;LUA;decor"; // decor is for Dano's decors
-_EXPORT const char kLanguageCommentStart[] = "--";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.lua";
-_EXPORT const int16 kInterfaceVersion = 2;
-}
+const char kLanguageName[] = "Lua";
+const char kLanguageExtensions[] = "lua;Lua;LUA;decor"; // decor is for Dano's decors
+const char kLanguageCommentStart[] = "--";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.lua";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START,

--- a/Languages/Sources/Mathematica_Language.cpp
+++ b/Languages/Sources/Mathematica_Language.cpp
@@ -36,12 +36,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-_EXPORT const char kLanguageName[] = "Mathematica";
-_EXPORT const char kLanguageExtensions[] = "m";
-_EXPORT const char kLanguageCommentStart[] = "(*";
-_EXPORT const char kLanguageCommentEnd[] = "*)";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.m";
-_EXPORT const int16 kInterfaceVersion = 2;
+const char kLanguageName[] = "Mathematica";
+const char kLanguageExtensions[] = "m";
+const char kLanguageCommentStart[] = "(*";
+const char kLanguageCommentEnd[] = "*)";
+const char kLanguageKeywordFile[] = "keywords.m";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START, IDENT, OTHER, COMMENT, STRING,

--- a/Languages/Sources/Oberon_Language.cpp
+++ b/Languages/Sources/Oberon_Language.cpp
@@ -36,12 +36,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-_EXPORT const char kLanguageName[] = "Oberon-2";
-_EXPORT const char kLanguageExtensions[] = "ob2;Mod";
-_EXPORT const char kLanguageCommentStart[] = "(*";
-_EXPORT const char kLanguageCommentEnd[] = "*)";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.ob2";
-_EXPORT const int16 kInterfaceVersion = 2;
+const char kLanguageName[] = "Oberon-2";
+const char kLanguageExtensions[] = "ob2;Mod";
+const char kLanguageCommentStart[] = "(*";
+const char kLanguageCommentEnd[] = "*)";
+const char kLanguageKeywordFile[] = "keywords.ob2";
+const int16 kInterfaceVersion = 2;
 
 _EXPORT bool Balance(CLanguageProxy& proxy, int32& start, int32& end)
 {

--- a/Languages/Sources/Pascal_Language.cpp
+++ b/Languages/Sources/Pascal_Language.cpp
@@ -40,14 +40,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-extern "C" {
-_EXPORT const char kLanguageName[] = "Pascal";
-_EXPORT const char kLanguageExtensions[] = "pas;pp;inc";
-_EXPORT const char kLanguageCommentStart[] = "//";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.pas";
-_EXPORT const int16 kInterfaceVersion = 2;
-}
+const char kLanguageName[] = "Pascal";
+const char kLanguageExtensions[] = "pas;pp;inc";
+const char kLanguageCommentStart[] = "//";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.pas";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START,

--- a/Languages/Sources/Perl_Language.cpp
+++ b/Languages/Sources/Perl_Language.cpp
@@ -36,12 +36,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-_EXPORT const char kLanguageName[] = "Perl";
-_EXPORT const char kLanguageExtensions[] = "pl";
-_EXPORT const char kLanguageCommentStart[] = "#";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.pl";
-_EXPORT const int16 kInterfaceVersion = 2;
+const char kLanguageName[] = "Perl";
+const char kLanguageExtensions[] = "pl";
+const char kLanguageCommentStart[] = "#";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.pl";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START, IDENT, OTHER, COMMENT, LCOMMENT, STRING1, STRING2,

--- a/Languages/Sources/Python_Language.cpp
+++ b/Languages/Sources/Python_Language.cpp
@@ -36,12 +36,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-_EXPORT const char kLanguageName[] = "Python";
-_EXPORT const char kLanguageExtensions[] = "py";
-_EXPORT const char kLanguageCommentStart[] = "#";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.py";
-_EXPORT const int16 kInterfaceVersion = 2;
+const char kLanguageName[] = "Python";
+const char kLanguageExtensions[] = "py";
+const char kLanguageCommentStart[] = "#";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.py";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START, IDENT, OTHER, COMMENT, LCOMMENT, STRING1, STRING2, STRING3,

--- a/Languages/Sources/Recipe_Language.cpp
+++ b/Languages/Sources/Recipe_Language.cpp
@@ -43,12 +43,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-_EXPORT const char kLanguageName[] = "Recipe";
-_EXPORT const char kLanguageExtensions[] = "recipe";
-_EXPORT const char kLanguageCommentStart[] = "#";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.recipe";
-_EXPORT const int16 kInterfaceVersion = 2;
+const char kLanguageName[] = "Recipe";
+const char kLanguageExtensions[] = "recipe";
+const char kLanguageCommentStart[] = "#";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.recipe";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START, IDENT, LCOMMENT, STRING1, STRING2

--- a/Languages/Sources/Rez_Language.cpp
+++ b/Languages/Sources/Rez_Language.cpp
@@ -36,12 +36,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-_EXPORT const char kLanguageName[] = "Rez";
-_EXPORT const char kLanguageExtensions[] = "r;rez;rdef";
-_EXPORT const char kLanguageCommentStart[] = "//";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.rez";
-_EXPORT const int16 kInterfaceVersion = 2;
+const char kLanguageName[] = "Rez";
+const char kLanguageExtensions[] = "r;rez;rdef";
+const char kLanguageCommentStart[] = "//";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.rez";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START, IDENT, OTHER, COMMENT, LCOMMENT, STRING,

--- a/Languages/Sources/Ruby_Language.cpp
+++ b/Languages/Sources/Ruby_Language.cpp
@@ -46,14 +46,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-extern "C" {
-_EXPORT const char kLanguageName[] = "Ruby";
-_EXPORT const char kLanguageExtensions[] = "rb;rbw";
-_EXPORT const char kLanguageCommentStart[] = "#";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.rb";
-_EXPORT const int16 kInterfaceVersion = 2;
-}
+const char kLanguageName[] = "Ruby";
+const char kLanguageExtensions[] = "rb;rbw";
+const char kLanguageCommentStart[] = "#";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.rb";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START				= 0x00,

--- a/Languages/Sources/Rust_Language.cpp
+++ b/Languages/Sources/Rust_Language.cpp
@@ -34,14 +34,12 @@
 #include "HColorUtils.h"
 
 
-extern "C" {
-	_EXPORT const char	kLanguageName[]			= "Rust";
-	_EXPORT const char	kLanguageExtensions[]	= "rs";
-	_EXPORT const char	kLanguageCommentStart[]	= "//";
-	_EXPORT const char	kLanguageCommentEnd[]	= "";
-	_EXPORT const char	kLanguageKeywordFile[]	= "keywords.rs";
-	_EXPORT const int16	kInterfaceVersion		= 2;
-}
+const char	kLanguageName[]			= "Rust";
+const char	kLanguageExtensions[]	= "rs";
+const char	kLanguageCommentStart[]	= "//";
+const char	kLanguageCommentEnd[]	= "";
+const char	kLanguageKeywordFile[]	= "keywords.rs";
+const int16	kInterfaceVersion		= 2;
 
 
 enum {

--- a/Languages/Sources/Shell_Language.cpp
+++ b/Languages/Sources/Shell_Language.cpp
@@ -36,12 +36,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-_EXPORT const char kLanguageName[] = "Shell";
-_EXPORT const char kLanguageExtensions[] = "sh;make;Makefile;makefile";
-_EXPORT const char kLanguageCommentStart[] = "#";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.sh";
-_EXPORT const int16 kInterfaceVersion = 2;
+const char kLanguageName[] = "Shell";
+const char kLanguageExtensions[] = "sh;make;Makefile;makefile";
+const char kLanguageCommentStart[] = "#";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.sh";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START, IDENT, LCOMMENT, STRING1, STRING2

--- a/Languages/Sources/Sql_Language.cpp
+++ b/Languages/Sources/Sql_Language.cpp
@@ -39,14 +39,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-extern "C" {
-_EXPORT const char kLanguageName[] = "SQL";
-_EXPORT const char kLanguageExtensions[] = "sql";
-_EXPORT const char kLanguageCommentStart[] = "#";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.sql";
-_EXPORT const int16 kInterfaceVersion = 2;
-}
+const char kLanguageName[] = "SQL";
+const char kLanguageExtensions[] = "sql";
+const char kLanguageCommentStart[] = "#";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.sql";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START,

--- a/Languages/Sources/Tex_Language.cpp
+++ b/Languages/Sources/Tex_Language.cpp
@@ -36,12 +36,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-_EXPORT const char kLanguageName[] = "TeX";
-_EXPORT const char kLanguageExtensions[] = "tex";
-_EXPORT const char kLanguageCommentStart[] = "%";
-_EXPORT const char kLanguageCommentEnd[] = "";
-_EXPORT const char kLanguageKeywordFile[] = "keywords.tex";
-_EXPORT const int16 kInterfaceVersion = 2;
+const char kLanguageName[] = "TeX";
+const char kLanguageExtensions[] = "tex";
+const char kLanguageCommentStart[] = "%";
+const char kLanguageCommentEnd[] = "";
+const char kLanguageKeywordFile[] = "keywords.tex";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START, COMMAND1, COMMAND2, CONSTCHAR,

--- a/Languages/Sources/Xml_Language.cpp
+++ b/Languages/Sources/Xml_Language.cpp
@@ -43,14 +43,12 @@
 #include "CLanguageAddOn.h"
 #include "HColorUtils.h"
 
-extern "C" {
-_EXPORT const char  kLanguageName[] = "XML";
-_EXPORT const char  kLanguageExtensions[] = "xml";
-_EXPORT const char  kLanguageCommentStart[] = "<!";
-_EXPORT const char  kLanguageCommentEnd[] = ">";
-_EXPORT const char  kLanguageKeywordFile[] = "keywords.xml";
-_EXPORT const int16 kInterfaceVersion = 2;
-}
+const char  kLanguageName[] = "XML";
+const char  kLanguageExtensions[] = "xml";
+const char  kLanguageCommentStart[] = "<!";
+const char  kLanguageCommentEnd[] = ">";
+const char  kLanguageKeywordFile[] = "keywords.xml";
+const int16 kInterfaceVersion = 2;
 
 enum {
 	START,

--- a/Sources/CCharObject.cpp
+++ b/Sources/CCharObject.cpp
@@ -56,7 +56,11 @@ BHandler *CCharObject::GetSubSpecifier(BMessage *msg, int32 index,
 
 void CCharObject::MessageReceived(BMessage *msg)
 {
+#if __GNUC__ == 2
 	std::auto_ptr<CCharObject> destroy(this);
+#else
+	std::unique_ptr<CCharObject> destroy(this);
+#endif
 
 	switch (msg->what)
 	{

--- a/Sources/CKeyCapturer.cpp
+++ b/Sources/CKeyCapturer.cpp
@@ -191,7 +191,7 @@ void CKeyCapturer::DescribeKeys(const KeyShortcut& ks, char *desc)
 		if (isprint(key[0]))
 			strcat(desc, key);
 		else
-			switch (key[0])
+			switch ((unsigned char)key[0])
 			{
 				case B_BACKSPACE:		strcat(desc, "Backspace");	break;
 				case B_TAB:				strcat(desc, "Tab");		break;

--- a/Sources/CLineObject.cpp
+++ b/Sources/CLineObject.cpp
@@ -83,7 +83,11 @@ BHandler *CLineObject::GetSubSpecifier(BMessage *msg, int32 index,
 
 void CLineObject::MessageReceived(BMessage *msg)
 {
+#if __GNUC__ == 2
 	std::auto_ptr<CLineObject> destroy(this);
+#else
+	std::unique_ptr<CLineObject> destroy(this);
+#endif
 
 	switch (msg->what)
 	{

--- a/Sources/HLazyObject.cpp
+++ b/Sources/HLazyObject.cpp
@@ -49,7 +49,11 @@ HLazyObject::~HLazyObject()
 BHandler *HLazyObject::ResolveSpecifier(BMessage *msg, int32 index,
 						BMessage *specifier, int32 form, const char *property)
 {
+#if __GNUC__ == 2
 	std::auto_ptr<HLazyObject> lets_commit_suicide(this);
+#else
+	std::unique_ptr<HLazyObject> lets_commit_suicide(this);
+#endif
 	BHandler *result = NULL;
 
 //	if (index > 0)

--- a/Sources/PApp.cpp
+++ b/Sources/PApp.cpp
@@ -87,7 +87,7 @@ static void SaveRecentMenu()
 
 static void RestoreRecentMenu()
 {
-	char name[12];
+	BString name;
 	int i = gRecentBufferSize;
 	const char *path;
 
@@ -95,8 +95,8 @@ static void RestoreRecentMenu()
 	{
 		try
 		{
-			sprintf(name, "recentdoc%d", i--);
-			path = gPrefs->GetPrefString(name);
+			name.SetToFormat("recentdoc%d", i--);
+			path = gPrefs->GetPrefString(name.String());
 			if (path)
 				PDoc::AddRecent(path);
 		}

--- a/Sources/PApp.cpp
+++ b/Sources/PApp.cpp
@@ -156,7 +156,7 @@ PApp::PApp()
 			else
 			{
 				BEntry d;
-				FailOSErr(e.FindEntry("pe", &d, B_DIRECTORY_NODE));
+				FailOSErr(e.FindEntry("pe", &d, B_DIRECTORY_NODE != 0));
 				FailOSErr(gPrefsDir.SetTo(&d));
 			}
 		}

--- a/Sources/PMessageWindow.cpp
+++ b/Sources/PMessageWindow.cpp
@@ -193,7 +193,11 @@ void PMessageItem::DrawItem(BView *owner, BRect bounds, bool /*complete*/)
 
 	p.Set(30, bounds.top + fh.ascent);
 
-	if (fErr) owner->DrawString(fErr, strlen(fErr) - 1, p); p.y += lineHeight;
+	if (fErr)
+		owner->DrawString(fErr, strlen(fErr) - 1, p);
+
+	p.y += lineHeight;
+
 	if (fSrc)
 	{
 		for (int i = 0; i < strlen(fSrc); i++)


### PR DESCRIPTION
Only 2 warnings remain on some of the Language extensions (Tex, and HTML-JS).

Left each commit separated, in case someone wants to cherry-pick instead of merge/squash them all.