### PR TITLE
"diff mode" improvements.

### DIFF
--- a/Sources/CDiffWindow.cpp
+++ b/Sources/CDiffWindow.cpp
@@ -396,6 +396,10 @@ void CDiffWindow::Work()
 		}
 		
 		ArrangeWindows();
+
+		fScript->Select(0);
+		fScript->MakeFocus(true);
+		Activate();
 	}
 	catch (HErr& e)
 	{

--- a/Sources/PApp.cpp
+++ b/Sources/PApp.cpp
@@ -646,8 +646,9 @@ void PApp::ArgvReceived(int32 argc, const char *argv[], const char * cwd)
 		}
 
 		if (invokeDiff == 2) {
-			// Size doesn't matter here as the window will be resized right away.
-			BRect r(0, 0, 0, 0);
+			// CDiffWindow get resized right away, but not if files are equal, so...
+			// Provide some sane defaults for its size.
+			BRect r(100, 100, 500, 250);
 			CDiffWindow *ndw = new CDiffWindow(r, "Differences");
 
 			BMessage msg(msg_Add2Files);


### PR DESCRIPTION
1.- Fix tiny "Differences", window if files are an exact match.

I think that, ideally, no windows should open if files are identical, and the "diff mode" was invoked from the command line / lpe.

But that can be a future improvement.

2.- Make sure the "Differences" window is the active one, and the that the focus is on the list of differences.