### PR TITLE
Use separate "generated" dirs per arch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-*generated/
+*generated*/
 rez/rez

--- a/Jamrules
+++ b/Jamrules
@@ -1,9 +1,3 @@
-
-# The directories used by the build.
-BUILD_DIR			= [ FDirName $(TOP) build ] ;
-GENERATED_DIR		= [ FDirName $(TOP) generated ] ;
-DISTRO_DIR			= [ FDirName $(TOP) generated distro ] ;
-
 # First find out which gcc version the platform uses.
 IS_GCC_4_PLATFORM = ;
 if $(OS) = HAIKU {
@@ -18,6 +12,22 @@ if $(OS) = HAIKU {
 		# ECHO "IS_GCC_4_PLATFORM =" $(IS_GCC_4_PLATFORM) ;
 	}
 }
+
+ARCH = $(OSPLAT) ;
+if $(OS) = HAIKU && $(OSPLAT) = X86 {
+	ARCH = x86_64 ;
+	if [ Glob /boot/system/lib/x86 : libbe.so ] {
+		ARCH = x86 ;
+		if ! $(IS_GCC_4_PLATFORM) {
+			ARCH = x86_gcc2 ;
+		}
+	}
+}
+
+# The directories used by the build.
+BUILD_DIR			= [ FDirName $(TOP) build ] ;
+GENERATED_DIR		?= [ FDirName $(TOP) generated.$(ARCH) ] ;
+DISTRO_DIR			?= [ FDirName $(GENERATED_DIR) distro ] ;
 
 include [ FDirName $(BUILD_DIR) HelperRules ] ;
 include [ FDirName $(BUILD_DIR) ConfigRules ] ;
@@ -66,4 +76,3 @@ actions MakeDistro
 	ln -sfn $(COMMON_FOLDER)/bin $(DISTRO_DIR)/\(drag\ lpe\ here\ to\ install\) ;
 	cp -a $(COMMON_FOLDER)/lib/libpcre*.so $(DISTRO_DIR)/lib/ ;
 }
-

--- a/build/BuildSettings
+++ b/build/BuildSettings
@@ -98,11 +98,11 @@ rule SetUpSubDirBuildSettings {
 	# set the objects-folder according to debugging settings:
 	if $(DEBUG) && $(DEBUG) != 0
 	{
-		OBJECTS_DIR			= [ FDirName $(TOP) generated objects-debug ] ;
+		OBJECTS_DIR			= [ FDirName $(GENERATED_DIR) objects-debug ] ;
 	} 
 	else 
 	{
-		OBJECTS_DIR			= [ FDirName $(TOP) generated objects-nodebug ] ;
+		OBJECTS_DIR			= [ FDirName $(GENERATED_DIR) objects-nodebug ] ;
 	}
 	
 	# debugging settings


### PR DESCRIPTION
This allows building, for example, for both 32 and 64 bits on x86 from a single repo clone,  right out of the box.

Kind of a silly workaround, but unless Jam provides something better than $OSPLAT... this will have to do.