### PR TITLE
Extensions: fix "Replace as tabs" by fixing the case in extensions names.

### DIFF
--- a/Extensions/Jamfile
+++ b/Extensions/Jamfile
@@ -29,7 +29,7 @@ PeExtension BeHappy
 # </pe-src>
 
 # <pe-src>
-PeExtension Copy\ Lines\ Containing 
+PeExtension Copy\ lines\ containing 
 	: CopyContaining.cpp 
 	: libhekkel.so pcreposix $(RX_LIB) be $(STDC++LIB) 
 	: copycon.r
@@ -37,21 +37,21 @@ PeExtension Copy\ Lines\ Containing
 # </pe-src>
 
 # <pe-src>
-PeExtension Cut\ Lines\ Containing 
+PeExtension Cut\ lines\ containing 
 	: CutContaining.cpp 
 	: libhekkel.so pcreposix $(RX_LIB) be $(STDC++LIB) 
 	;
 # </pe-src>
 
 # <pe-src>
-PeExtension Expand\ Tabs
+PeExtension Expand\ tabs
 	: ConvertTabs.cpp 
 	: libhekkel.so be $(STDC++LIB) 
 	;
 # </pe-src>
 
 # <pe-src>
-PeExtension Replace\ As\ Tabs
+PeExtension Replace\ as\ tabs
 	: ConvertTabs.cpp 
 	: libhekkel.so be $(STDC++LIB) 
 	;


### PR DESCRIPTION
Commit b8f4143c60b428ab91c1322c8d5594352cc6f515 changed UI strings to use "Haiku's sentence casing", but that change broke the "Replace As Tabs" extension (as it changed a non-user visible string in ConvertTabs.cpp that should have been kept in sync with the actual name of the extension's binary).

Fix by just using sentence casing for the extensions' binary names (those are the ones used in the menu).

Changed a couple other names' casing just for consistency.