### PR TITLE
Avoid crash on Find dialog.

### DIFF
--- a/Sources/CFindDialog.cpp
+++ b/Sources/CFindDialog.cpp
@@ -141,6 +141,9 @@ bool CRecentPatternController::AddCurrentPattern()
 
 void CRecentPatternController::Next()
 {
+	if (fPatternVect.empty())
+		return;
+
 	if (fCurrIdx == fPatternVect.size()-1)
 	{	// restore the saved pattern edited by user:
 		if (fSavedPattern.IsEmpty())


### PR DESCRIPTION
Pressing CTRL+down_arrow on a Find dialog, with no previous search patterns registered, was causing an "Exception (Segment violation)".